### PR TITLE
Fix failing React test

### DIFF
--- a/client/src/App.test.js
+++ b/client/src/App.test.js
@@ -1,8 +1,8 @@
 import { render, screen } from '@testing-library/react';
 import App from './App';
 
-test('renders learn react link', () => {
+test('renders home page heading', () => {
   render(<App />);
-  const linkElement = screen.getByText(/learn react/i);
-  expect(linkElement).toBeInTheDocument();
+  const heading = screen.getByText(/what is sustainat\?/i);
+  expect(heading).toBeInTheDocument();
 });


### PR DESCRIPTION
## Summary
- update App.test to check for expected heading text instead of outdated 'learn react' link

## Testing
- `npm test --silent --runInBand` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6863abc5d19c8325abb54124267f9953